### PR TITLE
fix(content): typo

### DIFF
--- a/Chapters/intro.qmd
+++ b/Chapters/intro.qmd
@@ -23,7 +23,7 @@ Both researchers, at least, agree upon one thing: *the practice of machine learn
 
 
 
-![Richard Feynman, Nobel laureate physicist.](/Images/Feynman){.column-margin #fig-feynman width=90%}
+![Richard Feynman, Nobel laureate physicist.](/Images/feynman){.column-margin #fig-feynman width=90%}
 
 
 ### A Tale of Babylonians and Greeks {#sec-greeks}


### PR DESCRIPTION
Use available path for an SVG that shows Feynman.

I have noticed that the figure

> ![](https://fredguth.github.io/IBToDL/Images/Feynman.svg)
>
> `https://fredguth.github.io/IBToDL/Images/Feynman.svg`

is not shown.

> ![](https://fredguth.github.io/IBToDL/Images/feynman.svg)
>
> `https://fredguth.github.io/IBToDL/Images/feynman.svg`

rather is.

I wonder why there is no file extension, but I do not care enough to settle this consideration right now. Is this change enough to show the image on:

* [The emergence of an Information Bottleneck Theory of Deep Learning - 1  Introduction](https://fredguth.github.io/IBToDL/Chapters/context.html)